### PR TITLE
Links are no longer needed in compose V2 if depends on is used, links…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,6 @@ version: '2'
 services:
   todo:
     build: .
-    links:
-      - postgres
-      - redis
     volumes:
       - .:/todo
     depends_on:


### PR DESCRIPTION
… where used to create a network connection between services. This is now done by compose by default